### PR TITLE
Fix Exception handling to be the same with older embulk-parser-csv

### DIFF
--- a/src/main/java/org/embulk/parser/csv/CsvParserPlugin.java
+++ b/src/main/java/org/embulk/parser/csv/CsvParserPlugin.java
@@ -338,13 +338,9 @@ public class CsvParserPlugin implements ParserPlugin {
                     }
                 }
 
-                try {
-                    if (!tokenizer.nextRecord()) {
-                        // empty file
-                        continue;
-                    }
-                } catch (final InvalidCsvFormatException ex) {
-                    throw new DataException(ex);
+                if (!tokenizer.nextRecord()) {
+                    // empty file
+                    continue;
                 }
 
                 while (true) {
@@ -473,6 +469,8 @@ public class CsvParserPlugin implements ParserPlugin {
             }
 
             pageBuilder.finish();
+        } catch (final InvalidCsvFormatException ex) {
+            throw new DataException(ex);
         }
     }
 


### PR DESCRIPTION
No problems have been observed about this so far, but trying to let its Exception handling to be the same with the original `embulk-standards`:

https://github.com/embulk/embulk/blob/v0.9.25/embulk-standards/src/main/java/org/embulk/standards/CsvParserPlugin.java#L263-L266